### PR TITLE
Add support for multi character classes

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,6 +81,19 @@ jobs:
           warning_classes: E,F
           error_classes: W,B
           only_warn: 1
+
+  run_action_with_empty_warningclasses:
+    name: Test run action (empty warning classes)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          plugins: flake8-bugbear
+          path: example_bugbear
+          error_classes: W,E,F
+          # B should be considered as warning per default
+          only_warn: 1
     
   run_action_with_multichar_classes:
     name: Test run action (multi character classes)

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,6 +81,19 @@ jobs:
           warning_classes: E,F
           error_classes: W,B
           only_warn: 1
+    
+  run_action_with_multichar_classes:
+    name: Test run action (multi character classes)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+            plugins: flake8-black
+            path: example_black
+            ignore: E,F,W,C                 # ignore everything except BLK
+            error_classes: BLK
+            only_warn: 1
 
   codespell:
     name: Check for spelling errors

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -20,7 +20,7 @@ else
     error_classes_bounded="${error_classes_bounded}${escaped_D}"
   fi
   echo "error_classes_bounded: ${error_classes_bounded}"
-  sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})${escaped_D}*/g" "${ACTION_FOLDER}/flake8-matcher.json"
+  sed -i "s/{{warning_expression}}/(?!${error_classes_bounded})${escaped_D}*/g" "${ACTION_FOLDER}/flake8-matcher.json"
   echo "matcher:"
   echo "$(cat ${ACTION_FOLDER}/flake8-matcher.json)"
 fi

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -19,10 +19,7 @@ else
   if ! [ -z "${error_classes_bounded}" ]; then
     error_classes_bounded="${error_classes_bounded}${escaped_D}"
   fi
-  echo "error_classes_bounded: ${error_classes_bounded}"
   sed -i "s/{{warning_expression}}/(?!${error_classes_bounded})${escaped_D}*/g" "${ACTION_FOLDER}/flake8-matcher.json"
-  echo "matcher:"
-  echo "$(cat ${ACTION_FOLDER}/flake8-matcher.json)"
 fi
 echo "::add-matcher::${ACTION_FOLDER}/flake8-matcher.json"
 

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -16,6 +16,7 @@ else
   # if error classes string is not empty, append delimiter
   if [ -z "${error_classes_bounded}" ]; then
     error_classes_bounded+="\\D"
+  fi
   sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})\\D*/g" "${ACTION_FOLDER}/flake8-matcher.json"
 fi
 echo "::add-matcher::${ACTION_FOLDER}/flake8-matcher.json"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -15,7 +15,7 @@ else
   error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\D|/g")
   # if error classes string is not empty, append delimiter
   if ! [ -z "${error_classes_bounded}" ]; then
-    error_classes_bounded+="\\D"
+    error_classes_bounded="${error_classes_bounded}\\D"
   fi
   echo "error_classes_bounded: ${error_classes_bounded}"
   sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})\\D*/g" "${ACTION_FOLDER}/flake8-matcher.json"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -12,10 +12,10 @@ if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
   # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
-  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\D|/g")
+  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\\\D|/g")
   # if error classes string is not empty, append delimiter
   if ! [ -z "${error_classes_bounded}" ]; then
-    error_classes_bounded="${error_classes_bounded}\\D"
+    error_classes_bounded="${error_classes_bounded}\\\\D"
   fi
   echo "error_classes_bounded: ${error_classes_bounded}"
   sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})\\D*/g" "${ACTION_FOLDER}/flake8-matcher.json"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -14,7 +14,7 @@ else
   # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
   error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\D|/g")
   # if error classes string is not empty, append delimiter
-  if [! -z "${error_classes_bounded}" ]; then
+  if ! [ -z "${error_classes_bounded}" ]; then
     error_classes_bounded+="\\D"
   fi
   echo "error_classes_bounded: ${error_classes_bounded}"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -4,14 +4,14 @@
 ACTION_FOLDER=$(dirname ${0})
 echo " - error_classes: '${INPUT_ERROR_CLASSES}'"
 error_classes=$(echo "${INPUT_ERROR_CLASSES}" | sed "s/,//g")
-sed -i "s/{{error_classes}}/${error_classes}/g" "${ACTION_FOLDER}/flake8-matcher.json"
+sed -i "s/{{error_expression}}/(?:${error_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 
 echo " - warning_classes: '${INPUT_WARNING_CLASSES}'"
 if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   warning_classes=$(echo "${INPUT_WARNING_CLASSES}" | sed "s/,//g")
-  sed -i "s/{{warning_classes}}/${warning_classes}/g" "${ACTION_FOLDER}/flake8-matcher.json"
+  sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
-  sed -i "s/{{warning_classes}}/^${error_classes}/g" "${ACTION_FOLDER}/flake8-matcher.json"
+  sed -i "s/{{warning_expression}}/^(?:${error_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 fi
 echo "::add-matcher::${ACTION_FOLDER}/flake8-matcher.json"
 

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
   # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
-  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\\\\\D|/g")
+  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\\\\\\\D|/g")
   # if error classes string is not empty, append delimiter
   if ! [ -z "${error_classes_bounded}" ]; then
     error_classes_bounded="${error_classes_bounded}\\\\\\D"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -12,9 +12,9 @@ if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
   # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
-  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/|\\\D/g")
+  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\D|/g")
   # if error classes string is not empty, append delimiter
-  if [ -z "${error_classes_bounded}" ]; then
+  if [! -z "${error_classes_bounded}" ]; then
     error_classes_bounded+="\\D"
   fi
   echo "error_classes_bounded: ${error_classes_bounded}"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -11,7 +11,12 @@ if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   warning_classes=$(echo "${INPUT_WARNING_CLASSES}" | sed "s/,/|/g")
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
-  sed -i "s/{{warning_expression}}/^(?:${error_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
+  # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
+  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/|\\\D/g")
+  # if error classes string is not empty, append delimiter
+  if [ -z "${error_classes_bounded}" ]; then
+    error_classes_bounded+="\\D"
+  sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})\\D*/g" "${ACTION_FOLDER}/flake8-matcher.json"
 fi
 echo "::add-matcher::${ACTION_FOLDER}/flake8-matcher.json"
 

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -17,7 +17,10 @@ else
   if [ -z "${error_classes_bounded}" ]; then
     error_classes_bounded+="\\D"
   fi
+  echo "error_classes_bounded: ${error_classes_bounded}"
   sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})\\D*/g" "${ACTION_FOLDER}/flake8-matcher.json"
+  echo "matcher:"
+  echo "$(cat ${ACTION_FOLDER}/flake8-matcher.json)"
 fi
 echo "::add-matcher::${ACTION_FOLDER}/flake8-matcher.json"
 

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -12,10 +12,10 @@ if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
   # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
-  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\\\D|/g")
+  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\\\\\D|/g")
   # if error classes string is not empty, append delimiter
   if ! [ -z "${error_classes_bounded}" ]; then
-    error_classes_bounded="${error_classes_bounded}\\\\D"
+    error_classes_bounded="${error_classes_bounded}\\\\\\D"
   fi
   echo "error_classes_bounded: ${error_classes_bounded}"
   sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})\\D*/g" "${ACTION_FOLDER}/flake8-matcher.json"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
   # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
-  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/\\\\\\\\\\D|/g")
+  error_classes_bounded=$(echo "${error_classes}" | sed 's/|/\\D|/g')
   # if error classes string is not empty, append delimiter
   if ! [ -z "${error_classes_bounded}" ]; then
     error_classes_bounded="${error_classes_bounded}\\\\\\D"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -3,12 +3,12 @@
 # Enable the matcher.
 ACTION_FOLDER=$(dirname ${0})
 echo " - error_classes: '${INPUT_ERROR_CLASSES}'"
-error_classes=$(echo "${INPUT_ERROR_CLASSES}" | sed "s/,//g")
+error_classes=$(echo "${INPUT_ERROR_CLASSES}" | sed "s/,/|/g")
 sed -i "s/{{error_expression}}/(?:${error_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 
 echo " - warning_classes: '${INPUT_WARNING_CLASSES}'"
 if [ -n "${INPUT_WARNING_CLASSES}" ]; then
-  warning_classes=$(echo "${INPUT_WARNING_CLASSES}" | sed "s/,//g")
+  warning_classes=$(echo "${INPUT_WARNING_CLASSES}" | sed "s/,/|/g")
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
   sed -i "s/{{warning_expression}}/^(?:${error_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -11,14 +11,16 @@ if [ -n "${INPUT_WARNING_CLASSES}" ]; then
   warning_classes=$(echo "${INPUT_WARNING_CLASSES}" | sed "s/,/|/g")
   sed -i "s/{{warning_expression}}/(?:${warning_classes})/g" "${ACTION_FOLDER}/flake8-matcher.json"
 else
+  escaped_D='\\\\D'
+  double_escaped_D='\\\\\\\\D'
   # add "word boundaries" (but with digits) to distinguish between "B" and "BLK"
-  error_classes_bounded=$(echo "${error_classes}" | sed 's/|/\\D|/g')
+  error_classes_bounded=$(echo "${error_classes}" | sed "s/|/${double_escaped_D}|/g")
   # if error classes string is not empty, append delimiter
   if ! [ -z "${error_classes_bounded}" ]; then
-    error_classes_bounded="${error_classes_bounded}\\\\\\D"
+    error_classes_bounded="${error_classes_bounded}${escaped_D}"
   fi
   echo "error_classes_bounded: ${error_classes_bounded}"
-  sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})\\D*/g" "${ACTION_FOLDER}/flake8-matcher.json"
+  sed -i "s/{{warning_expression}}/^(?!${error_classes_bounded})${escaped_D}*/g" "${ACTION_FOLDER}/flake8-matcher.json"
   echo "matcher:"
   echo "$(cat ${ACTION_FOLDER}/flake8-matcher.json)"
 fi

--- a/action/flake8-matcher.json
+++ b/action/flake8-matcher.json
@@ -5,7 +5,7 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]*):(\\d+):(\\d+): ([{{error_classes}}]\\d\\d\\d) (.*)$",
+                    "regexp": "^([^:]*):(\\d+):(\\d+): ((?:{{error_classes}})\\d\\d\\d) (.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
@@ -19,7 +19,7 @@
             "severity": "warning",
             "pattern": [
                 {
-                    "regexp": "^([^:]*):(\\d+):(\\d+): ([{{warning_classes}}]\\d\\d\\d) (.*)$",
+                    "regexp": "^([^:]*):(\\d+):(\\d+): ((?:{{warning_classes}})\\d\\d\\d) (.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/action/flake8-matcher.json
+++ b/action/flake8-matcher.json
@@ -5,7 +5,7 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]*):(\\d+):(\\d+): ((?:{{error_classes}})\\d\\d\\d) (.*)$",
+                    "regexp": "^([^:]*):(\\d+):(\\d+): ({{error_expression}}\\d\\d\\d) (.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
@@ -19,7 +19,7 @@
             "severity": "warning",
             "pattern": [
                 {
-                    "regexp": "^([^:]*):(\\d+):(\\d+): ((?:{{warning_classes}})\\d\\d\\d) (.*)$",
+                    "regexp": "^([^:]*):(\\d+):(\\d+): ({{warning_expression}}\\d\\d\\d) (.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,

--- a/example_black/example.py
+++ b/example_black/example.py
@@ -1,0 +1,5 @@
+# black will complain, it wants it like this: j = [1, 2, 3]
+j = [1,
+     2,
+     3
+]


### PR DESCRIPTION
As the test `run_action_with_multichar_classes` shows, the original error/warning class regex did not support multi-character classes like `BLK `provided from [flake8-black](https://github.com/peterjc/flake8-black) as it was interpreted as a choice of characters.
To enable also support for multi-character-classnames, a non-capturing group with a choice of strings is used now. Unfortunately, the other way round ("all except the error classes" if waring class string is not provided) is a little bit more complicated now, as it needs a negative lookahead instead of just inverting a character set.
As both regex selector now differ, their inner part is now constructed in the shell script.
To ensure also the mechanism for empty warning classes is working correctly, another test is added.